### PR TITLE
Remove .rtf artifacts

### DIFF
--- a/pull-request-template.md
+++ b/pull-request-template.md
@@ -1,15 +1,6 @@
-{\rtf1\ansi\ansicpg1252\cocoartf2511
-\cocoatextscaling0\cocoaplatform0{\fonttbl\f0\fswiss\fcharset0 Helvetica;}
-{\colortbl;\red255\green255\blue255;}
-{\*\expandedcolortbl;;}
-\margl1440\margr1440\vieww10800\viewh8400\viewkind0
-\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\pardirnatural\partightenfactor0
-
-\f0\fs24 \cf0 #### What's this PR do?\
-#### Where should the reviewer start?\
-#### How should this be manually tested?\
-#### Any background context you want to provide?\
-#### What are the relevant tickets?\
-#### Screenshots (if appropriate)\
-#### Questions:\
-}
+#### Where should the reviewer start?
+#### How should this be manually tested?
+#### Any background context you want to provide?
+#### What are the relevant tickets?
+#### Screenshots (if appropriate)
+#### Questions:


### PR DESCRIPTION
```
{\rtf1\ansi\ansicpg1252\cocoartf2511
\cocoatextscaling0\cocoaplatform0{\fonttbl\f0\fswiss\fcharset0 Helvetica;}
{\colortbl;\red255\green255\blue255;}
{\*\expandedcolortbl;;}
\margl1440\margr1440\vieww10800\viewh8400\viewkind0
\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\pardirnatural\partightenfactor0

\f0\fs24 \cf0
``` 
#### What's this PR do?
Removes all the stuff above
#### Where should the reviewer start?\
No Review needed
#### Any background context you want to provide?\
This happened because I created the template in TextEditor and then changed the file-type after saving